### PR TITLE
feat: use binary in slim docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,15 +70,8 @@ RUN cd /app/ \
 ##                                                       ##
 ###########################################################
 
-
-# Official Bun image
-FROM oven/bun:${BUN_VERSION} as automation-prod
-
-# Bun uses NODE_ENV for backward compatibility with Node
-ENV NODE_ENV="production"
-
-# Simplicity first
-WORKDIR /app
+# Must be compatible with executable from Builder
+FROM debian:buster-slim
 
 # Open Container Initiative (OCI) labels
 LABEL org.opencontainers.image.title="Automation Standalone" \
@@ -91,11 +84,12 @@ LABEL org.opencontainers.image.title="Automation Standalone" \
       org.opencontainers.image.authors="Webber Takken <webber@takken.io>" \
       org.opencontainers.image.licenses="MIT"
 
+# Simplicity first
+WORKDIR /app
+
 # Copy the distributable files and production specific dependencies
 COPY --from=builder /app/dist /app/package.json ./
-COPY --from=builder /app/node_modules node_modules
 
 # Run the app
-USER bun
 EXPOSE 3000
-ENTRYPOINT [ "bun", "run", "server.js" ]
+CMD ["./server"]

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "bun --hot --watch src/main.ts",
     "sync": "yarn up \"@digital-alchemy/*\" && bunx --env-file .env type-writer",
     "build": "bun --env-file .env build:docker",
-    "build:dist": "bun build src/main.ts --target=bun --outfile=dist/server.js",
+    "build:dist": "bun build src/main.ts --compile --minify --outfile dist/server",
     "build:docker": "docker build . --build-arg HASS_TOKEN=$HASS_TOKEN --build-arg HASS_BASE_URL=$HASS_BASE_URL -t automation-prod",
     "start": "docker run --env-file .env automation-prod",
     "test": "vitest",


### PR DESCRIPTION
#### Changes

- Move away from bun official image in favour of minimal image running a binary instead.
- Resolves: https://github.com/Digital-Alchemy-TS/automation-standalone/issues/11

## Research

Did a quick research to compare running the application using Bun, as a binary on Debian and as a binary on Alpine. Here are the results:

### Option: run typescript files on the offical bun image, running `bun server.js`

Build command

```bash
bun build src/main.ts --target=bun --outfile=dist/server.js
```

Production image (simplified)
```dockerfile
FROM oven/bun:${BUN_VERSION} as automation-prod
ENV NODE_ENV="production"
WORKDIR /app
COPY --from=builder /app/dist /app/package.json ./
COPY --from=builder /app/node_modules node_modules
USER bun
EXPOSE 3000
CMD [ "bun", "run", "server.js" ]
```

Size: 232MB (OS = 213MB, application = 3MB (of which source map 2MB), node modules 16MB
Coldstart bootstrap: 982ms

---

### Option: binary on `debian:buster-slim` image

Build command
```bash
bun build src/main.ts --compile --minify --outfile dist/server
```

production image
```dockerfile
FROM debian:buster-slim
WORKDIR /app
COPY --from=builder /app/dist /app/package.json ./
CMD ["./server"]
``` 

Size: 169MB
Coldstart bootstrap: 991ms

---

### Option: binary on `alpine`

Executable didn't work because it's built on `bitnami/node`, which uses debian.

Size: 107MB (OS = 5MB, Binary = 102MB (of which Sourcemap is 2MB))

Tried fixes:
-  `apk add gcompat`  different error: Error relocating /app/server: unsupported relocation type 37
-  `apk add libc6-compat` different error: Error relocating /app/server: unsupported relocation type 37

Both of those seem to cryptically indicate that you're missing shared libs or other files

> If you want to use one or more files on Alpine Linux which were compiled on a glibc based operating system, then you are responsible for ensuring that all of the shared libraries they need are available at runtime. I am unable to help you with this process.

Sources used:
- https://stackoverflow.com/questions/66963068/docker-alpine-executable-binary-not-found-even-if-in-path
- https://github.com/sgerrand/alpine-pkg-glibc/issues/194
- https://github.com/sgerrand/alpine-pkg-glibc/issues/157#issuecomment-835433778

Conclusion: 
- Installing those linker deps and then also the missing libraries will most likely add about 30 megs, at which point we're half way up to the debian slim image again. 
- Since this is not a deployment intensive enterprise scale application I'm deeming it to probably not be worth the hassle - unless somebody has specific experience in this field


#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [x] Tests (added, updated or not needed)
